### PR TITLE
Add Discord server start webhook

### DIFF
--- a/code/controllers/configuration/entries/general.dm
+++ b/code/controllers/configuration/entries/general.dm
@@ -495,3 +495,6 @@
 
 /datum/config_entry/flag/reopen_roundstart_suicide_roles_command_report
 
+/datum/config_entry/string/webhook_roundstart
+    protection = CONFIG_ENTRY_HIDDEN
+

--- a/code/modules/discord_notify/notify_all.dm
+++ b/code/modules/discord_notify/notify_all.dm
@@ -1,0 +1,17 @@
+SUBSYSTEM_DEF(discord_notify)
+    name = "Notifier"
+    wait = 3000
+    init_order = INIT_ORDER_DEFAULT
+
+/datum/controller/subsystem/discord_notify/Initialize(start_timeofday)
+    if(!CONFIG_GET(flag/hub))
+        can_fire = 0
+        return ..()
+    var/webhook = CONFIG_GET(string/webhook_roundstart)
+    if(webhook)
+        var/datum/http_request/R = new()
+        R.prepare(RUSTG_HTTP_METHOD_POST, webhook, "{\"content\":\"<@&1254782534626312203>\\n\",\"embeds\":[{\"title\":\"Round [GLOB.rogue_round_id] is starting soon!!\",\"description\":\"\",\"color\":16711680}]}",
+            list("Content-Type" = "application/json"), "")
+        R.begin_async()
+    can_fire = 0
+    return ..()

--- a/roguetown.dme
+++ b/roguetown.dme
@@ -1330,6 +1330,7 @@
 #include "code\modules\discord\manipulation.dm"
 #include "code\modules\discord\tgs_commands.dm"
 #include "code\modules\discord\toggle_notify.dm"
+#include "code\modules\discord_notify\notify_all.dm"
 #include "code\modules\droning\droning.dm"
 #include "code\modules\economy\_economy.dm"
 #include "code\modules\economy\account.dm"


### PR DESCRIPTION
## Summary
- ping Discord via webhook when the server starts
- add `webhook_roundstart` config entry

## Testing
- `python tools/ci/validate_dme.py < roguetown.dme` (errors: file not included, etc.)
- `./tools/ci/check_grep.sh` (errors: Initialize override without 'mapload' argument)
- `./tools/ci/check_misc.sh` (JSON errors)
- `./tools/ci/check_changelogs.sh`
- `./tools/ci/run_server.sh roguetown.dme` (missing compiled assets)


------
https://chatgpt.com/codex/tasks/task_e_68948671f2f48320bac5269aa6588e75