### PR TITLE
Auto agevet whitelist players and grant PQ bonus

### DIFF
--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -825,6 +825,7 @@ GLOBAL_LIST_EMPTY(external_rsc_urls)
 		player_details = new(ckey)
 		player_details.byond_version = full_version
 		GLOB.player_details[ckey] = player_details
+	check_agevet()
 
 #if (PRELOAD_RSC == 0)
 	preload_rsc = GLOB.external_rsc_urls[1]

--- a/modular/code/modules/admin/agevetting.dm
+++ b/modular/code/modules/admin/agevetting.dm
@@ -7,16 +7,26 @@ GLOBAL_LIST_INIT(agevetted_list, load_agevets_from_file())
 GLOBAL_PROTECT(agevetted_list)
 
 /client/proc/check_agevet()
-	if(LAZYACCESS(GLOB.agevetted_list, ckey) || holder)
+	if(LAZYACCESS(GLOB.agevetted_list, ckey))
+		return TRUE
+	if(check_whitelist(ckey))
+		if(!LAZYACCESS(GLOB.agevetted_list, ckey))
+			add_agevet(ckey, "SYSTEM", src)
+		return TRUE
+	if(holder)
 		return TRUE
 	return FALSE
 
 /mob/proc/check_agevet()
-	if(client)
-		return client.check_agevet()
-	if(LAZYACCESS(GLOB.agevetted_list, ckey) || copytext(key,1,2)=="@") //aghosted people stay verified
-		return TRUE
-	return FALSE
+       if(client)
+               return client.check_agevet()
+       if(LAZYACCESS(GLOB.agevetted_list, ckey) || copytext(key,1,2)=="@") //aghosted people stay verified
+               return TRUE
+       if(check_whitelist(ckey))
+               if(!LAZYACCESS(GLOB.agevetted_list, ckey))
+                       add_agevet(ckey, "SYSTEM")
+               return TRUE
+       return FALSE
 
 /client/proc/agevet_player()
 	set category = "-GameMaster-"
@@ -43,6 +53,7 @@ GLOBAL_PROTECT(agevetted_list)
 
 	target_ckey = ckey(target_ckey)
 	GLOB.agevetted_list[target_ckey] = admin_ckey
+	adjust_playerquality(10, target_ckey, admin_ckey, "Age verification bonus")
 	message_admins("ID VETTING: Added [target_ckey] to the agevetted list[admin_ckey? " by [admin_ckey]":""]")
 	log_admin("ID VETTING: Added [target_ckey] to the agevetted list[admin_ckey? " by [admin_ckey]":""]")
 	save_agevets_to_file()


### PR DESCRIPTION
## Summary
- Ensure age checks add whitelisted players to the age-vetted list before skipping admin holders, so all whitelisted players gain PQ
- Trigger age verification on login to automatically grant the +10 PQ bonus to whitelisted players

## Testing
- `python3 tools/ci/validate_dme.py < roguetown.dme` *(fails: file not included)*

------
https://chatgpt.com/codex/tasks/task_e_68948879fc3c8320a60fddaa13b1ca61