### PR TITLE
Remove maneaters from mapgen

### DIFF
--- a/code/modules/roguetown/mapgen/beach.dm
+++ b/code/modules/roguetown/mapgen/beach.dm
@@ -16,7 +16,6 @@
 	spawnableAtoms = list(/obj/structure/flora/newtree = 15,
 							/obj/structure/flora/roguegrass/bush = 8,
 							/obj/structure/flora/roguegrass = 20,
-							/obj/structure/flora/roguegrass/maneater = 16,
 							/obj/item/natural/stone = 18,
 							/obj/item/natural/rock = 2,
 							/obj/item/grown/log/tree/stick = 3,
@@ -30,7 +29,6 @@
 	allowed_turfs = list(/turf/open/floor/rogue/grass)
 	spawnableAtoms = list(/obj/structure/flora/roguegrass/bush = 5,
 							/obj/structure/flora/roguegrass = 35,
-							/obj/structure/flora/roguegrass/maneater = 4,
 							/obj/item/natural/stone = 8,
 							/obj/item/natural/rock = 2,
 							/obj/item/grown/log/tree/stick = 10)

--- a/code/modules/roguetown/mapgen/bog.dm
+++ b/code/modules/roguetown/mapgen/bog.dm
@@ -18,7 +18,6 @@
 	spawnableAtoms = list(/obj/structure/flora/newtree = 30,
 							/obj/structure/flora/roguegrass/bush = 10,
 							/obj/structure/flora/roguegrass = 26,
-							/obj/structure/flora/roguegrass/maneater = 13,
 							/obj/item/natural/stone = 23,
 							/obj/item/natural/rock = 6,
 							/obj/item/magic/artifact = 4,
@@ -31,8 +30,7 @@
 							/obj/structure/flora/roguetree/stump = 4,
 							/obj/structure/closet/dirthole/closed/loot = 3,
 							/obj/structure/flora/roguegrass/swampweed = 10,
-							/obj/structure/flora/roguegrass/bush/westleach = 10,
-							/obj/structure/flora/roguegrass/maneater/real = 3)
+							/obj/structure/flora/roguegrass/bush/westleach = 10)
 	spawnableTurfs = list(/turf/open/floor/rogue/dirt/road=2,
 						/turf/open/water/swamp=1)
 	allowed_areas = list(/area/rogue/outdoors/bog)
@@ -59,8 +57,6 @@
 							/obj/structure/flora/roguetree/wise=5,
 							/obj/structure/flora/roguegrass/bush = 10,
 							/obj/structure/flora/roguegrass = 44,
-							/obj/structure/flora/roguegrass/maneater = 15,
-							/obj/structure/flora/roguegrass/maneater/real = 10,
 							/obj/item/natural/stone = 6,
 							/obj/item/natural/rock = 1,
 							/obj/item/grown/log/tree/stick = 3,

--- a/code/modules/roguetown/mapgen/decap.dm
+++ b/code/modules/roguetown/mapgen/decap.dm
@@ -20,7 +20,6 @@
 	/obj/structure/flora/grass/green = 20,
 	/obj/item/grown/log/tree/stick = 16,
 	/obj/structure/flora/roguegrass/pyroclasticflowers = 3,
-	/obj/structure/flora/roguegrass/maneater/real=3,
 	/obj/structure/flora/roguegrass/herb/random = 5)
 	spawnableTurfs = list(/turf/open/floor/rogue/snowpatchy=15)
 	allowed_areas = list(/area/rogue/outdoors/mountains/decap)

--- a/code/modules/roguetown/mapgen/forest.dm
+++ b/code/modules/roguetown/mapgen/forest.dm
@@ -20,15 +20,13 @@
 							/obj/structure/flora/roguegrass = 200,
 							/obj/structure/flora/roguegrass/herb/random = 7,
 							/obj/structure/flora/roguegrass/bush/westleach = 7,
-							/obj/structure/flora/roguegrass/maneater = 13,
 							/obj/structure/flora/roguegrass/pyroclasticflowers = 3,
 							/obj/item/natural/stone = 23,
 							/obj/item/natural/rock = 6,
 							/obj/item/grown/log/tree/stick = 16,
 							/obj/structure/flora/roguetree/stump/log = 3,
 							/obj/structure/flora/roguetree/stump = 4,
-							/obj/structure/closet/dirthole/closed/loot=3,
-							/obj/structure/flora/roguegrass/maneater/real=3)
+							/obj/structure/closet/dirthole/closed/loot=3)
 	spawnableTurfs = list(/turf/open/floor/rogue/dirt/road=2,
 						/turf/open/water/swamp=1)
 	allowed_areas = list(/area/rogue/outdoors/woods)
@@ -56,8 +54,6 @@
 							/obj/structure/flora/roguegrass = 200,
 							/obj/structure/flora/roguegrass/herb/random = 7,
 							/obj/structure/flora/roguegrass/bush/westleach = 7,
-							/obj/structure/flora/roguegrass/maneater = 13,
-							/obj/structure/flora/roguegrass/maneater/real=2,
 							/obj/item/natural/stone = 6,
 							/obj/item/natural/rock = 1,
 							/obj/item/grown/log/tree/stick = 3,

--- a/code/modules/roguetown/mapgen/rogueoutdoors.dm
+++ b/code/modules/roguetown/mapgen/rogueoutdoors.dm
@@ -17,7 +17,6 @@
 	spawnableAtoms = list(/obj/structure/flora/newtree = 5,
 							/obj/structure/flora/roguegrass/bush = 13,
 							/obj/structure/flora/roguegrass = 40,
-							/obj/structure/flora/roguegrass/maneater = 16,
 							/obj/item/natural/stone = 18,
 							/obj/item/natural/rock = 2,
 							/obj/item/grown/log/tree/stick = 3,
@@ -47,7 +46,6 @@
 	allowed_turfs = list(/turf/open/floor/rogue/dirt,/turf/open/floor/rogue/grass,/turf/open/floor/rogue/grassred,/turf/open/floor/rogue/grassyel,/turf/open/floor/rogue/grasscold)
 	excluded_turfs = list(/turf/open/floor/rogue/dirt/road)
 	spawnableAtoms = list(/obj/structure/flora/roguegrass = 40,
-						/obj/structure/flora/roguegrass/maneater = 7,
 							/obj/item/natural/stone = 18,
 							/obj/item/grown/log/tree/stick = 3)
 	allowed_areas = list(/area/rogue/outdoors/town,/area/rogue/outdoors/rtfield)


### PR DESCRIPTION
## About The Pull Request

Removes maneaters from all mapgen, so that they don't spawn in the forest at roundstart. They may still be spawned in manually.

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence

I've booted up the default map and walked around in the forest. No maneaters in sight, but everything else seems to be generating normally.

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game

I don't really care about maneaters' presence. I was asked to make this PR due to them being, at times, game-breakingly buggy (e.g. snatching people from ~6 tiles away) and annoying in general.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
