### PR TITLE
Second scabbard for DR Zeybeks selecting shamshirs

### DIFF
--- a/code/modules/jobs/job_types/roguetown/mercenaries/classes/desertrider.dm
+++ b/code/modules/jobs/job_types/roguetown/mercenaries/classes/desertrider.dm
@@ -96,7 +96,7 @@
 	)
 
 	subclass_skills = list(
-		/datum/skill/combat/swords = SKILL_LEVEL_JOURNEYMAN, 
+		/datum/skill/combat/swords = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/combat/knives = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/combat/whipsflails = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/combat/maces = SKILL_LEVEL_APPRENTICE,
@@ -141,6 +141,7 @@
 	switch(weapon_choice)
 		if("Shamshir and Javelin")
 			H.adjust_skillrank_up_to(/datum/skill/combat/swords, SKILL_LEVEL_EXPERT, TRUE)
+			beltr = /obj/item/rogueweapon/scabbard/sword
 			r_hand = /obj/item/rogueweapon/sword/sabre/shamshir
 			backl = /obj/item/quiver/javelin/iron
 		if("Whips and Knives")	///They DO enslave people after all


### PR DESCRIPTION
## About The Pull Request

Desert Rider Zeybek mercenaries selecting the Shamshir and Javelin weapon set will now receive two scabbards for their two swords instead of just one.

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence

I've compiled the build with no errors and joined the round as a DR Zeybek merc. Everything spawns in with no issues.

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game

They use two swords, it's like their main thing, so why only one scabbard? Let them have two, for aesthetics's sake.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
